### PR TITLE
Exclude models and templates from code coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <sonar.organization>docutest-1</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.exclusions>**/models/*, **/templates/*</sonar.exclusions>
     </properties>
 
     <dependencies>
@@ -181,6 +182,12 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.5</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/models/*</exclude>
+                        <exclude>**/templates/*</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Forgot to include sonar.exclusions property in the previous commit.